### PR TITLE
Modified to allow use of EC2 instance profile

### DIFF
--- a/carrot-nexus-aws-s3-publish-plugin/pom.xml
+++ b/carrot-nexus-aws-s3-publish-plugin/pom.xml
@@ -96,7 +96,7 @@
 		<dependency>
 			<groupId>com.amazonaws</groupId>
 			<artifactId>aws-java-sdk</artifactId>
-			<version>1.3.26</version>
+			<version>1.6.11</version>
 			<exclusions>
 				<!-- nexus conflict -->
 				<exclusion>

--- a/carrot-nexus-aws-s3-publish-plugin/readme.md
+++ b/carrot-nexus-aws-s3-publish-plugin/readme.md
@@ -67,6 +67,8 @@ Nexus -> Administration -> Capabilities
 
 which needs be configured with your amazon credentials, email address, etc.;
 
+alternatively, you may leave amazon credentials blank and use an ec2 instance profile for authentication;
+
 if you delete all plugin configurations, default configuration 
 will be re-created again on nexus restart;
 

--- a/carrot-nexus-aws-s3-publish-plugin/src/main/resources/reference.conf
+++ b/carrot-nexus-aws-s3-publish-plugin/src/main/resources/reference.conf
@@ -92,21 +92,21 @@
 	form-field-bundle {
 	
 		aws-access {
-			required=true
+			required=false
 			type="string"
 			default-value="unknown"
 			label="AWS Access Key ID"
 			help-link="http://docs.amazonwebservices.com/AWSSecurityCredentials/1.0/AboutAWSCredentials.html"
-			help-text="Access Key ID—Your Access Key ID identifies you as the party responsible for service requests. You include it in each request, so it's not a secret."
+			help-text="Access Key ID—Your Access Key ID identifies you as the party responsible for service requests. You include it in each request, so it's not a secret. If not provided, the plugin will attempt to use instance profile credentials."
 		}
 		
 		aws-secret {
-			required=true
+			required=false
 			type="string"
 			default-value="unknown"
 			label="AWS Secret Access Key"
 			help-link="http://docs.amazonwebservices.com/AWSSecurityCredentials/1.0/AboutAWSCredentials.html"
-			help-text="Secret Access Key—Each Access Key ID has a Secret Access Key associated with it. This key is just a long string of characters (and not a file) that you use to calculate the digital signature that you include in the request. Your Secret Access Key is a secret, and only you and AWS should have it."
+			help-text="Secret Access Key—Each Access Key ID has a Secret Access Key associated with it. This key is just a long string of characters (and not a file) that you use to calculate the digital signature that you include in the request. Your Secret Access Key is a secret, and only you and AWS should have it. If not provided, the plugin will attempt to use instance profile credentials."
 		}
 
 		endpoint {
@@ -137,6 +137,7 @@
 		}
 		
 		health-period {
+			required=true
 			type="number"
 			default-value="60"
 			label="Health Check Period"


### PR DESCRIPTION
If credentials are not provided, the plugin will attempt to use an EC2
instance profile to authenticate to S3.

This required:
- Creating a new CredentialsProvider that will offer either the credentials provided in config or the credentials obtained via InstanceProfile.
- Upping aws-java-sdk version to latest
- Making access key and secret access key config parameters optional.

During the course of testing I also found that if I had not provided a value for health check period, the plugin would not successfully activate.  I changed this option to be required.
